### PR TITLE
Update versions and do some miscellaneous clean-up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
-script: sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate && sbt ++$TRAVIS_SCALA_VERSION validateJS
+script:
+  if [[ "$TRAVIS_BRANCH" == "scalajs" ]];
+    then sbt ++$TRAVIS_SCALA_VERSION validateJS;
+    else sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate;
+  fi
 
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,13 @@ lazy val baseSettings = Seq(
   libraryDependencies ++= Seq(
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ),
-  resolvers += Resolver.sonatypeRepo("snapshots")
+  resolvers ++= Seq(
+    Resolver.sonatypeRepo("releases"),
+    Resolver.sonatypeRepo("snapshots")
+  )
 )
 
-lazy val allSettings = buildSettings ++ baseSettings ++ testSettings ++ unidocSettings ++ publishSettings
+lazy val allSettings = buildSettings ++ baseSettings ++ testSettings ++ publishSettings
 
 lazy val commonJsSettings = Seq(
   postLinkJSEnv := NodeJSEnv().value,
@@ -81,8 +84,7 @@ lazy val core = crossProject
   .settings(allSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.spire-math" %%% "cats-core" % catsVersion,
-      "org.spire-math" %%% "cats-std" % catsVersion
+      "org.spire-math" %%% "cats-core" % catsVersion
     )
   )
   .jvmSettings(
@@ -99,7 +101,7 @@ lazy val generic = crossProject
   .settings(moduleName := "circe-generic")
   .settings(allSettings: _*)
   .settings(
-    libraryDependencies += "com.chuusai" %%% "shapeless" % "2.2.5"
+    libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.0-SNAPSHOT"
   )
   .jsSettings(commonJsSettings: _*)
   .dependsOn(core, core % "test->test")
@@ -217,11 +219,7 @@ val jsProjects = Seq(
 )
 
 addCommandAlias("buildJVM", jvmProjects.map(";" + _ + "/test:compile").mkString)
-
 addCommandAlias("validateJVM", ";buildJVM" + jvmProjects.map(";" + _ + "/test").mkString + ";scalastyle")
-
 addCommandAlias("buildJS", jsProjects.map(";" + _ + "/test:compile").mkString)
-
 addCommandAlias("validateJS", ";buildJS" + jsProjects.map(";" + _ + "/test").mkString + ";scalastyle")
-
 addCommandAlias("validate", ";validateJVM;validateJS")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This removes the now unnecessary `cats-std` dependency, bumps the circe snapshot version to 0.2.0, updates the SBT version, switches to the current Shapeless snapshot (which seems to greatly improve compile times), and adds a conditional to the Travis config so that the Scala.js build is only tested for the `scalajs` branch.

I've got a few other things I want to get into circe 0.2.0 that I'll be working on this weekend, so I'm not too worried about waiting for both cats 0.1.3 and Shapeless 2.3.0 for that release.
